### PR TITLE
Fix room persistence on refresh

### DIFF
--- a/gameLogic.js
+++ b/gameLogic.js
@@ -236,7 +236,10 @@ window.addEventListener("beforeunload", () => {
   const navType = navEntries.length ? navEntries[0].type : null;
 
   // Yenileme durumunda çıkış yapma
-  if (navType === "reload") return;
+  if (navType === "reload") {
+    sessionStorage.setItem("reloading", "true");
+    return;
+  }
 
   // Sekme kapandıysa veya tarayıcı kapandıysa
   unloadTimer = setTimeout(() => {

--- a/main.js
+++ b/main.js
@@ -3,18 +3,27 @@ window.addEventListener("DOMContentLoaded", () => {
   let currentPlayerName = localStorage.getItem("playerName") || null;
   let isCreator = localStorage.getItem("isCreator") === "true";
 
+  // Geçerli sayfa yenileme işaretini temizle
+  sessionStorage.removeItem("reloading");
+
   /** ------------------------
    *  SAYFA KAPANIRSA (Kurucu değilse) odadan çık
    *  - F5 yenilemede çıkmaz
    *  - Tarayıcı / sekme kapanınca çıkar
    * ------------------------ */
   let isRefreshing = false;
-  window.addEventListener("beforeunload", (e) => {
-    if (performance.getEntriesByType("navigation")[0].type === "reload") {
+
+  window.addEventListener("beforeunload", () => {
+    const navEntries = performance.getEntriesByType("navigation");
+    const navType = navEntries.length ? navEntries[0].type : null;
+    if (navType === "reload") {
       isRefreshing = true;
+      sessionStorage.setItem("reloading", "true");
     }
   });
+
   window.addEventListener("unload", () => {
+    if (sessionStorage.getItem("reloading") === "true") return;
     if (!isRefreshing && currentRoomCode && currentPlayerName && !isCreator) {
       navigator.sendBeacon(
         "/leave-room",


### PR DESCRIPTION
## Summary
- preserve session info during page reloads
- add `sessionStorage` flag to ignore unload logic on refresh

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_688a1447b5dc832db0a9fe8b95a1c690